### PR TITLE
Support Graph API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.5.8

--- a/README.md
+++ b/README.md
@@ -67,10 +67,15 @@ def get_token_from_code(auth_code)
                               :authorize_url => "/common/oauth2/v2.0/authorize",
                               :token_url => "/common/oauth2/v2.0/token")
 
+  # For a shortcut to resource permission scope to Outlook API Calendar.ReadWrite, you can use `resource`
   token = client.auth_code.get_token(auth_code,
                                      :redirect_uri => "http://yourapp.com/authorize",
                                      :resource => 'https://outlook.office365.com')
 
+  # For Microsoft Graph API,
+  token = client.auth_code.get_token(auth_code,
+                                     :redirect_uri => "http://yourapp.com/authorize",
+                                     :scope => "offline_access https://graph.microsoft.com/Calendars.ReadWrite")
   access_token = token
 end
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ In addition, you can set the `enable_fiddler` property on the `Client` to true i
 
 ### Get an OAuth2 token ###
 
+see https://docs.microsoft.com/en-us/graph/tutorials/ruby?view=graph-rest-1.0
+https://docs.microsoft.com/en-us/outlook/rest/compare-graph#azure-v2-oauth2-endpoint
+
 The Outlook APIs require an OAuth2 token for authentication. This gem doesn't handle the OAuth2 flow for you. For a full example that implements the OAuth2 [Authorization Code Grant Flow](https://msdn.microsoft.com/en-us/library/azure/dn645542.aspx), see the [Office 365 VCF Import/Export Sample](https://github.com/jasonjoh/o365-vcftool).
 
 For convenience, here's the relevant steps and code, which uses the [oauth2](https://rubygems.org/gems/oauth2) gem.
@@ -46,8 +49,8 @@ def get_login_url
   client = OAuth2::Client.new(CLIENT_ID,
                               CLIENT_SECRET,
                               :site => "https://login.microsoftonline.com",
-                              :authorize_url => "/common/oauth2/authorize",
-                              :token_url => "/common/oauth2/token")
+                              :authorize_url => "/common/oauth2/v2.0/authorize",
+                              :token_url => "/common/oauth2/v2.0/token")
 
   login_url = client.auth_code.authorize_url(:redirect_uri => "http://yourapp.com/authorize")
 end
@@ -61,8 +64,8 @@ def get_token_from_code(auth_code)
   client = OAuth2::Client.new(CLIENT_ID,
                               CLIENT_SECRET,
                               :site => "https://login.microsoftonline.com",
-                              :authorize_url => "/common/oauth2/authorize",
-                              :token_url => "/common/oauth2/token")
+                              :authorize_url => "/common/oauth2/v2.0/authorize",
+                              :token_url => "/common/oauth2/v2.0/token")
 
   token = client.auth_code.get_token(auth_code,
                                      :redirect_uri => "http://yourapp.com/authorize",

--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -26,7 +26,8 @@ module RubyOutlook
     # params (hash) a Ruby hash containing any query parameters needed for the API call
     # payload (hash): a JSON hash representing the API call's payload. Only used
     #                 for POST or PATCH.
-    def make_api_call(method, url, token, params = nil, payload = {})
+    # custom_headers (hash) a Ruby hash of additional headers (eg setting 'x-AnchorMailbox' or 'client-request-id')
+    def make_api_call(method, url, token, params = nil, payload = {}, custom_headers=nil)
 
       conn_params = {
         :url => 'https://outlook.office365.com'
@@ -53,6 +54,10 @@ module RubyOutlook
         'return-client-request-id' => "true"
       }
 
+      if custom_headers && custom_headers.class == Hash
+        conn.headers = conn.headers.merge( custom_headers )
+      end
+      
       case method.upcase
         when "GET"
           response = conn.get do |request|

--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -1,6 +1,6 @@
 require "ruby_outlook/version"
 require "faraday"
-require "uuidtools"
+require 'securerandom'
 require "json"
 
 module RubyOutlook
@@ -49,7 +49,7 @@ module RubyOutlook
         # Client instrumentation
         # See https://msdn.microsoft.com/EN-US/library/office/dn720380(v=exchg.150).aspx
         'User-Agent' => @user_agent,
-        'client-request-id' => UUIDTools::UUID.timestamp_create.to_str,
+        'client-request-id' => SecureRandom.uuid,
         'return-client-request-id' => "true"
       }
 

--- a/lib/ruby_outlook.rb
+++ b/lib/ruby_outlook.rb
@@ -82,7 +82,15 @@ module RubyOutlook
       end
 
       if response.status >= 300
-        error_info = response.body.empty? ? '' : JSON.parse(response.body)
+        error_info = if response.body.empty?
+          ''
+          else
+            begin
+              JSON.parse( response.body )
+            rescue JSON::ParserError => _e
+              response.body
+            end
+        end
         return JSON.dump({
           'ruby_outlook_error' => response.status,
           'ruby_outlook_response' => error_info })

--- a/lib/run-tests.rb
+++ b/lib/run-tests.rb
@@ -1,28 +1,44 @@
-require './ruby_outlook'
+# Run from project root like `ruby -Ilib ./lib/run-tests.rb`
+require './lib/ruby_outlook.rb'
 require 'json'
+require 'date' # Needed on Mac to use DateTime
 
 # TODO: Copy a valid, non-expired access token here.
 access_token = 'eyJ0eXAiOiJKV1QiLCJhbGciO...'
+DEBUG = !ENV['DEBUG'].nil?
+
+# Use CONTACT_ID to GET a pre-existing contact (instead of contact created by test), eg
+# 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAEOAACDgDrpyW-uTL4a3VuSIF6OAAAZHKwnAAA='
+CONTACT_ID = ENV['CONTACT_ID']
+
+# Use MESSAGE_ID to GET a pre-existing message (instead of message created by test), eg
+# 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAEMAACDgDrpyW-uTL4a3VuSIF6OAAAZHKJNAAA='
+MESSAGE_ID = ENV['MESSAGE_ID']
+
+# Use EVENT_ID to GET a pre-existing event (instead of event created by test), eg
+# 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAENAACDgDrpyW-uTL4a3VuSIF6OAAAXZ15oAAA='
+EVENT_ID = ENV['EVENT_ID']
+
 
 def do_contact_api_tests(token)
-  # TODO: Copy a valid ID for a contact here
-  contact_id = 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAEOAACDgDrpyW-uTL4a3VuSIF6OAAAZHKwnAAA='
-
-  new_contact_payload = '{
+  new_contact_payload = <<~JSON % { address: 'pavelb@a830edad9050849NDA1.onmicrosoft.com'}
+  {
     "GivenName": "Pavel",
     "Surname": "Bansky",
     "EmailAddresses": [
       {
-        "Address": "pavelb@a830edad9050849NDA1.onmicrosoft.com",
+        "Address": "%{address}",
         "Name": "Pavel Bansky"
       }
     ],
     "BusinessPhones": [
       "+1 732 555 0102"
     ]
-  }'
+  }
+  JSON
 
-  update_contact_payload = '{
+  update_contact_payload = <<~JSON
+  {
     "HomeAddress": {
       "Street": "Some street",
       "City": "Seattle",
@@ -30,9 +46,15 @@ def do_contact_api_tests(token)
       "PostalCode": "98121"
     },
     "Birthday": "1974-07-22"
-  }'
+  }
+  JSON
 
-  outlook_client = RubyOutlook::Client.new
+  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
+
+  puts 'Testing POST /me/contacts'
+  new_contact_json = JSON.parse(new_contact_payload)
+  new_contact = outlook_client.create_contact token, new_contact_json
+  assert(true, new_contact)
 
   # Maximum 30 results per page.
   view_size = 30
@@ -48,43 +70,26 @@ def do_contact_api_tests(token)
   puts 'Testing GET /me/contacts'
   contacts = outlook_client.get_contacts token,
               view_size, page, fields, sort
-              
-  puts contacts
-  puts ""
+  assert(true, contacts)
 
   puts 'Testing GET /me/contacts/id'
-  contact = outlook_client.get_contact_by_id token, contact_id
-
-  puts contact
-  puts ""
-
-  puts 'Testing POST /me/contacts'
-  new_contact_json = JSON.parse(new_contact_payload)
-  new_contact = outlook_client.create_contact token, new_contact_json
-
-  puts new_contact
-  puts ""
+  contact = outlook_client.get_contact_by_id token, (CONTACT_ID || new_contact['Id'])
+  assert(true, contact)
 
   puts 'Testing PATCH /me/contacts/id'
   update_contact_json = JSON.parse(update_contact_payload)
   updated_contact = outlook_client.update_contact token, update_contact_json, new_contact['Id']
-
-  puts updated_contact
-  puts ""
+  assert(true, updated_contact)
 
   puts 'Testing DELETE /me/contacts/id'
   delete_response = outlook_client.delete_contact token, new_contact['Id']
-
-  puts delete_response.nil? ? "SUCCESS" : delete_response
-  puts ""
+  assert(delete_response.nil?, delete_response)
 end
 
 def do_mail_api_tests(token)
-  # TODO: Copy a valid ID for a message here
-  message_id = 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAEMAACDgDrpyW-uTL4a3VuSIF6OAAAZHKJNAAA='
-
-  new_message_payload = '{
-    "Subject": "Did you see last night\'s game?",
+  new_message_payload = <<~JSON % { address: "katiej@a830edad9050849NDA1.onmicrosoft.com" }
+  {
+    "Subject": "Did you see last night's game?",
     "Importance": "Low",
     "Body": {
       "ContentType": "HTML",
@@ -93,17 +98,21 @@ def do_mail_api_tests(token)
     "ToRecipients": [
       {
         "EmailAddress": {
-          "Address": "katiej@a830edad9050849NDA1.onmicrosoft.com"
+          "Address": "%{address}"
         }
       }
     ]
-  }'
+  }
+  JSON
 
-  update_message_payload = '{
+  update_message_payload =  <<~JSON
+  {
     "Subject": "UPDATED"
-  }'
+  }
+  JSON
   
-  send_message_payload = '{
+  send_message_payload = <<~JSON % { address: 'allieb@contoso.com'}
+  {
     "Subject": "Meet for lunch?",
     "Body": {
       "ContentType": "Text",
@@ -112,7 +121,7 @@ def do_mail_api_tests(token)
     "ToRecipients": [
       {
         "EmailAddress": {
-          "Address": "allieb@contoso.com"
+          "Address": "%{address}"
         }
       }
     ],
@@ -123,9 +132,15 @@ def do_mail_api_tests(token)
         "ContentBytes": "bWFjIGFuZCBjaGVlc2UgdG9kYXk="
       }
     ]
-  }'
+  }
+  JSON
   
-  outlook_client = RubyOutlook::Client.new
+  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
+
+  puts 'Testing POST /me/messages'
+  new_message_json = JSON.parse(new_message_payload)
+  new_message = outlook_client.create_message token, new_message_json
+  assert(true, new_message)
 
   # Maximum 30 results per page.
   view_size = 30
@@ -141,85 +156,97 @@ def do_mail_api_tests(token)
   puts 'Testing GET /me/messages'
   messages = outlook_client.get_messages token,
               view_size, page, fields, sort
-              
-  puts messages
-  puts ""
+  assert(true, messages)
 
   puts 'Testing GET /me/messages/id'
-  message = outlook_client.get_message_by_id token, message_id
-
-  puts message
-  puts ""
-
-  puts 'Testing POST /me/messages'
-  new_message_json = JSON.parse(new_message_payload)
-  new_message = outlook_client.create_message token, new_message_json
-
-  puts new_message
-  puts ""
+  message = outlook_client.get_message_by_id token, (MESSAGE_ID || new_message['Id'])
+  assert(true, message)
 
   puts 'Testing PATCH /me/messages/id'
   update_message_json = JSON.parse(update_message_payload)
   updated_message = outlook_client.update_message token, update_message_json, new_message['Id']
-
-  puts updated_message
-  puts ""
+  assert(true, updated_message)
 
   puts 'Testing DELETE /me/messages/id'
   delete_response = outlook_client.delete_message token, new_message['Id']
+  assert(delete_response.nil?, delete_response)
 
-  puts delete_response.nil? ? "SUCCESS" : delete_response
-  puts ""
-  
   puts 'Testing POST /me/sendmail'
   send_message_json = JSON.parse(send_message_payload)
   send_response = outlook_client.send_message token, send_message_json
-  
-  puts send_response.nil? ? "SUCCESS" : send_response
-  puts ""
+  assert(send_response.nil?, send_response)
 end
 
 def do_calendar_api_tests(token)
-  # TODO: Copy a valid ID for an event here
-  event_id = 'AAMkADNhMjcxM2U5LWY2MmItNDRjYy05YzgwLWQwY2FmMTU1MjViOABGAAAAAAC_IsPnAGUWR4fYhDeYtiNFBwCDgDrpyW-uTL4a3VuSIF6OAAAAAAENAACDgDrpyW-uTL4a3VuSIF6OAAAXZ15oAAA='
-
-  new_event_payload = '{
+  # NOTE: outlook api v1.0 => v2.0 changed the format of 'Start'/'End' from string-encoded-time to object DateTime/TimeZone
+  #   "Start": "2014-07-02T18:00:00Z",
+  #   "End": "2014-07-02T19:00:00Z",
+  # became
+  #       "Start": {
+  #           "DateTime": "2014-02-02T18:00:00",
+  #           "TimeZone": "Pacific Standard Time"
+  #       },
+  #       "End": {
+  #           "DateTime": "2014-02-02T19:00:00",
+  #           "TimeZone": "Pacific Standard Time"
+  #       },
+  # Having the wrong format returns a http 400 UnableToDeserializePostBody
+  new_event_payload = <<~JSON % { address: 'janets@a830edad9050849NDA1.onmicrosoft.com'}
+  {
   "Subject": "Discuss the Calendar REST API",
   "Body": {
     "ContentType": "HTML",
     "Content": "I think it will meet our requirements!"
   },
-  "Start": "2014-07-02T18:00:00Z",
-  "End": "2014-07-02T19:00:00Z",
+  "Start": {
+    "DateTime": "2014-02-02T18:00:00",
+    "TimeZone": "Pacific Standard Time"
+  },
+  "End": {
+    "DateTime": "2014-02-02T19:00:00",
+    "TimeZone": "Pacific Standard Time"
+  },
   "Attendees": [
     {
       "EmailAddress": {
-        "Address": "janets@a830edad9050849NDA1.onmicrosoft.com",
+        "Address": "%{address}",
         "Name": "Janet Schorr"
       },
       "Type": "Required"
     }
   ]
-}'
+  }
+  JSON
 
-  update_event_payload = '{
+  update_event_payload = <<~JSON
+  {
   "Location": {
     "DisplayName": "Your office"
   }
-}'
+  }
+  JSON
   
-  outlook_client = RubyOutlook::Client.new
+  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
 
-  
+  # # Tried creating a Calendar to poke at create_event hitting a 400 UnableToDeserializePostBody, unsuccessfully
+  # # leaving it commented until gem also supports delete_calendar
+  # puts 'Testing POST /me/calendars'
+  # new_calendar = outlook_client.create_calendar token, { 'Name' => 'Social'}
+  # assert(true, new_calendar)
+
+
+  puts 'Testing POST /me/events'
+  new_event_json = JSON.parse(new_event_payload)
+  new_event = outlook_client.create_event token, new_event_json
+  assert(true, new_event)
+
   puts 'Testing GET /me/CalendarView'
-  
+
   start_time = DateTime.parse('2015-03-03T00:00:00Z')
   end_time = DateTime.parse('2015-03-10T00:00:00Z')
   view = outlook_client.get_calendar_view token, start_time, end_time
-              
-  puts view
-  puts ""
-  
+  assert(true, view)
+
     # Maximum 30 results per page.
   view_size = 30
   # Set the page from the query parameter.
@@ -234,36 +261,32 @@ def do_calendar_api_tests(token)
   puts 'Testing GET /me/events'
   events = outlook_client.get_events token,
               view_size, page, fields, sort
-              
-  puts events
-  puts ""
+  assert(true, events)
 
   puts 'Testing GET /me/events/id'
-  event = outlook_client.get_event_by_id token, event_id
-
-  puts event
-  puts ""
-
-  puts 'Testing POST /me/events'
-  new_event_json = JSON.parse(new_event_payload)
-  new_event = outlook_client.create_event token, new_event_json
-
-  puts new_event
-  puts ""
+  event = outlook_client.get_event_by_id token, (EVENT_ID || new_event['Id'])
+  assert(true, event)
 
   puts 'Testing PATCH /me/events/id'
   update_event_json = JSON.parse(update_event_payload)
   updated_event = outlook_client.update_event token, update_event_json, new_event['Id']
-
-  puts updated_event
-  puts ""
+  assert(true, updated_event)
 
   puts 'Testing DELETE /me/events/id'
   delete_response = outlook_client.delete_event token, new_event['Id']
+  assert(delete_response.nil?, delete_response)
+end
 
-  puts delete_response.nil? ? "SUCCESS" : delete_response
-  puts ""
-end 
+
+def assert(condition, response = nil)
+  puts response
+  if condition == false || (response.is_a?(Hash) && !response['ruby_outlook_error'].nil?)
+    exit -1
+  end
+
+  puts 'SUCCESS'
+  puts ''
+end
 
 do_contact_api_tests access_token
 do_mail_api_tests access_token

--- a/lib/run-tests.rb
+++ b/lib/run-tests.rb
@@ -49,7 +49,7 @@ def do_contact_api_tests(token)
   }
   JSON
 
-  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
+  outlook_client = RubyOutlook::Client.new(return_format: :pascal_case, debug: DEBUG)
 
   puts 'Testing POST /me/contacts'
   new_contact_json = JSON.parse(new_contact_payload)
@@ -135,7 +135,7 @@ def do_mail_api_tests(token)
   }
   JSON
   
-  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
+  outlook_client = RubyOutlook::Client.new(return_format: :pascal_case, debug: DEBUG)
 
   puts 'Testing POST /me/messages'
   new_message_json = JSON.parse(new_message_payload)
@@ -226,7 +226,7 @@ def do_calendar_api_tests(token)
   }
   JSON
   
-  outlook_client = RubyOutlook::Client.new(debug: DEBUG)
+  outlook_client = RubyOutlook::Client.new(return_format: :pascal_case, debug: DEBUG)
 
   # # Tried creating a Calendar to poke at create_event hitting a 400 UnableToDeserializePostBody, unsuccessfully
   # # leaving it commented until gem also supports delete_calendar

--- a/ruby_outlook.gemspec
+++ b/ruby_outlook.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   
   spec.add_dependency "faraday"
-  spec.add_dependency "uuidtools"
 
   spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Microsoft is deprecating the Outlook API, in favor of the Graph API.

These changes add support for using various API endpoints and versions.
To minimize impact in upgrade, the defined resource operations also support transforming keys between camelCase (Graph API) and PascalCase (Outlook API)

This PR also DRY's request setup and parsing as well as updates tests.